### PR TITLE
Implement $scalars helper functions to select all scalar fields

### DIFF
--- a/src/lib/codegen/builder/base.ts
+++ b/src/lib/codegen/builder/base.ts
@@ -21,6 +21,12 @@ export abstract class GeneratorSelectionTypeFlavor {
     public static readonly HelperTypes: string;
 
     /**
+     * The code for the helper functions.
+     * The helper functions are functions that are used by the selection type flavor.
+     */
+    public static readonly HelperFunctions: string;
+
+    /**
      * The metadata for the GraphQL type. Gathered from the schema.
      * @see gatherMeta for more information.
      * @see TypeMeta for more information.

--- a/src/lib/codegen/builder/generator.ts
+++ b/src/lib/codegen/builder/generator.ts
@@ -59,6 +59,7 @@ export class Generator {
         const code = [
             this.Codegen.FieldValueWrapperType,
             this.Codegen.HelperTypes,
+            this.Codegen.HelperFunctions,
             ...[...collector.enumsTypes.entries()]
                 .map(([_, code]) => code)
                 .filter((code, index, arr) => arr.indexOf(code) === index),


### PR DESCRIPTION
Usage:

```typescript
const { aliasedQuery } = await spacex((op) => ({
    aliasedQuery: op.query(({ company }) => ({
        company: company(({ $scalars, headquarters }) => ({
            ...$scalars(),
            hq: headquarters(({ $scalars }) => ({
                ...$scalars(),
            })),
        })),
    })),
}));
```