### PR TITLE
[AIC] Implement explicit fragments as feature

### DIFF
--- a/src/lib/codegen/flavors/default/generator-flavor.ts
+++ b/src/lib/codegen/flavors/default/generator-flavor.ts
@@ -146,11 +146,17 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
     ) => infer R
         ? R
         : never;
+    type ArgumentsTypeFromFragment<T> = T extends (
+        this: any,
+        ...args: infer A
+    ) => any
+        ? A
+        : never;
     
     type SelectionHelpers<S, T> = {
         $fragment: <F extends (this: any, ...args: any[]) => any>(
             f: F,
-        ) => ReturnTypeFromFragment<F>;
+        ) => (...args: ArgumentsTypeFromFragment<F>) => ReturnTypeFromFragment<F>;
         $scalars: () => ScalarsFromSelection<S, T>;
     };
     `;
@@ -477,7 +483,7 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                     collector: this,
                     fieldName: "",
                     isFragment: f.name,
-                })(),
+                }),
             $scalars: () =>
                 selectScalars(
                         make${selectionFunctionName}Input.bind(this)(),

--- a/src/lib/codegen/flavors/default/wrapper.ts
+++ b/src/lib/codegen/flavors/default/wrapper.ts
@@ -198,13 +198,14 @@ export class OperationSelectionCollector {
                     result[key] =
                         `... on ${value[SLW_IS_ON_TYPE_FRAGMENT]} ${subSelection}`;
                 } else if (value[SLW_IS_FRAGMENT]) {
-                    result[key] = `...${key}`;
-                    const fragment = `fragment ${key} on ${value[SLW_FIELD_TYPE]} ${subSelection}`;
-                    if (!usedFragments.has(key)) {
-                        usedFragments.set(key, fragment);
-                    } else if (usedFragments.get(key) !== fragment) {
+                    const fragmentName = `${key}_${subVarDefs.map((v) => v.split(":")[0].slice(1)).join("_")}`;
+                    result[key] = `...${fragmentName}`;
+                    const fragment = `fragment ${fragmentName} on ${value[SLW_FIELD_TYPE]} ${subSelection}`;
+                    if (!usedFragments.has(fragmentName)) {
+                        usedFragments.set(fragmentName, fragment);
+                    } else if (usedFragments.get(fragmentName) !== fragment) {
                         console.warn(
-                            `Fragment ${key} is already defined with a different selection`,
+                            `Fragment ${fragmentName} is already defined with a different selection`,
                         );
                     }
                 } else {


### PR DESCRIPTION
Example usage:

```typescript
import unions, { ArticleSelection } from "./unions2";

function titleOnly(this: any) {
    return ArticleSelection.bind(this)((s) => ({
        titleFromFragment: s.title,
    }));
}

const { op1 } = await unions((op) => ({
    op1: op.query((s) => ({
        b: s.books((s) => ({
            ...titleOnly(),
        })),
        a: s.articles((s) => ({
            ...s.$fragment(titleOnly),
        })),
        all: s.search(({ $on }) => ({
            ...$on.Book((s) => ({
                ...s.$scalars(),
            })),
            ...$on.Article((s) => ({
                ...s.$scalars(),
            })),
        })),
    })),
}));

// all books, with inline fragment
console.log(op1.b.map((b) => b.titleFromFragment));
// all articles, with named fragment (titleOnly) in query
console.log(op1.a);
// all books and articles, with union type and inline fragments
console.log(op1.all);
```

output: 

```typescript
[
    {
        query: `
        fragment titleOnly on Article { titleFromFragment: title  }
        
        query op1  {
            b: books {
                titleFromFragment: title
            }
            a: articles {
                ...titleOnly 
            }
            all: search {
                ... on Book { title author  }
                ... on Article { title publisher  }
            } 
        }
        `,
        variables: {},
    },
    {
        data: {
            b: [
                { titleFromFragment: "The Awakening" },
                { titleFromFragment: "City of Glass" },
            ],
            a: [
                { titleFromFragment: "GraphQL is awesome" },
                { titleFromFragment: "REST is dead" },
            ],
            all: [
                { title: "The Awakening", author: "Kate Chopin" },
                { title: "City of Glass", author: "Paul Auster" },
                { title: "GraphQL is awesome", publisher: "Apollo" },
                { title: "REST is dead", publisher: "Medium" },
            ],
        },
    },
    ["The Awakening", "City of Glass"],
    [
        {
            titleFromFragment: "GraphQL is awesome",
        },
        {
            titleFromFragment: "REST is dead",
        },
    ],
    [
        {
            title: "The Awakening",
            author: "Kate Chopin",
        },
        {
            title: "City of Glass",
            author: "Paul Auster",
        },
        {
            title: "GraphQL is awesome",
            publisher: "Apollo",
        },
        {
            title: "REST is dead",
            publisher: "Medium",
        },
    ],
];
```

## Implicit Inline Fragments
The exported "*Selection" functions can be used as implicit inline fragments from anywhere.
It can be used and constructed anywhere outside the operation and then object-spread into the selection. 
However, there is not typesafety for this right now. As one can see, the `ArticlesSelection` fragment also works on the Books type, because it also defines a `title` field.

## Explicitly defined query fragments
When used extensively in the Query, it may be useful to use real GraphQL fragments.
This can be done using the `$fragment` helper selection function and a separately defined fragment function.

`function titleOnly` is such a function. Please note, that it is defined as `function` and not an `arrow function`, because it needs to have it's own scope with `this`. Also, you need to pass the `this` via `bind` to the `*Selection` function, so that it get's registered as named fragment later on.

## Possible Usages
Apart from these requirements, you can do whatever you want in your custom fragment functions, opening possibilities to conditional and parameterized fragments (similar to what is being discussed here: https://github.com/graphql/graphql-spec/issues/204 )
In case of named parameterized fragments, I have not yet tested what the generated query will look like when there're arguments in the selection. It should collect and hoist them to variables in the query but still reference them in the fragment. This might not be valid gql, but you can still use Implicit Inline Fragments, so you have the convenience of fragments being defined once as code and have them generate the wanted gql code based on your input.
