### PR TITLE
Lazify Operations with magic $lazy property

### DIFF
--- a/src/lib/codegen/builder/base.ts
+++ b/src/lib/codegen/builder/base.ts
@@ -108,12 +108,9 @@ export abstract class GeneratorSelectionTypeFlavor {
         parents: string[],
     ): string;
 
-    public abstract makeSelectionFunction(): string;
+    public abstract makeSelectionFunction(schema: GraphQLSchema): string;
 
-    public static makeRootOperationFunction(
-        schema: GraphQLSchema,
-        collector: Collector,
-    ): string {
+    public static makeRootOperationFunction(collector: Collector): string {
         throw new Error("Method not implemented.");
     }
 }

--- a/src/lib/codegen/builder/collector.ts
+++ b/src/lib/codegen/builder/collector.ts
@@ -4,7 +4,24 @@ import { type TypeMeta } from "./meta";
  * Collects all recursively collected information during the code generation process.
  * This information is used to cut infinite loops in the code generation process.
  */
-export class Collector {
+export class Collector<
+    QT extends string | undefined = string | undefined,
+    MT extends string | undefined = string | undefined,
+    ST extends string | undefined = string | undefined,
+> {
+    public OperationTypeNames: (QT | MT | ST)[];
+    constructor(
+        public readonly QueryTypeName: QT,
+        public readonly MutationTypeName: MT,
+        public readonly SubscriptionTypeName: ST,
+    ) {
+        this.OperationTypeNames = [
+            QueryTypeName,
+            MutationTypeName,
+            SubscriptionTypeName,
+        ].filter((t) => t) as (QT | MT | ST)[];
+    }
+
     /**
      * The collected types.
      */

--- a/src/lib/codegen/builder/generator.ts
+++ b/src/lib/codegen/builder/generator.ts
@@ -30,7 +30,15 @@ export class Generator {
             headerName: string;
         };
     }): Promise<string> {
-        const collector = new Collector();
+        const QueryTypeName = schema.getQueryType()?.name;
+        const MutationTypeName = schema.getMutationType()?.name;
+        const SubscriptionTypeName = schema.getSubscriptionType()?.name;
+
+        const collector = new Collector(
+            QueryTypeName,
+            MutationTypeName,
+            SubscriptionTypeName,
+        );
         gatherMeta(schema, options, collector);
 
         // Generate selection types
@@ -78,11 +86,7 @@ export class Generator {
                     ([type]) => !type.isScalar && !type.isEnum && !type.isInput,
                 )
                 .map(([_, code]) => code),
-            this.Codegen.makeRootOperationFunction(
-                schema,
-                collector,
-                authConfig,
-            ),
+            this.Codegen.makeRootOperationFunction(collector, authConfig),
         ].join("\n");
 
         const prettyCode = await prettier.format(code, {

--- a/src/lib/codegen/flavors/default/generator-flavor.ts
+++ b/src/lib/codegen/flavors/default/generator-flavor.ts
@@ -675,23 +675,20 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                     ${helperFunctions}
                 } as const;
             };
-            export const ${selectionFunctionName} = (<
-                T extends object
-            >() =>
-               (makeSLFN as SLFN<
-                    T,
+            export const ${selectionFunctionName} = (makeSLFN as SLFN<
+                    {},
                     ReturnType<typeof make${selectionFunctionName}Input>,
                     "${selectionFunctionName}",
                     "${this.typeName}",
                     "${this.originalFullTypeName.replaceAll("[", "").replaceAll("]", "").replaceAll("!", "")}",
                     ${this.typeMeta.isList ?? 0}
                 >)(
-                    ${`make${selectionFunctionName}Input`} as any,
+                    ${`make${selectionFunctionName}Input`},
                     "${selectionFunctionName}",
                     "${this.typeName}",
                     "${this.originalFullTypeName.replaceAll("[", "").replaceAll("]", "").replaceAll("!", "")}",
                     ${this.typeMeta.isList ?? 0}
-            ))();
+            );
         `;
         this.collector.addSelectionFunction(this.typeMeta, selectionFunction);
 

--- a/src/lib/codegen/flavors/default/generator-flavor.ts
+++ b/src/lib/codegen/flavors/default/generator-flavor.ts
@@ -717,12 +717,10 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                             SLFN<
                                 T, 
                                 ReturnType<typeof make${QueryTypeName}SelectionInput>,
-                                "${QueryTypeName}",
                                 "${QueryTypeName}Selection",
                                 "${QueryTypeName}",
+                                "${QueryTypeName}",
                                 0,
-                                { $lazy: () => "T" },
-                                "$lazy"
                             >
                         >;`
                         : ""
@@ -737,12 +735,10 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                                         ReturnType<typeof make${MutationTypeName}SelectionInput>,
                                         ${MutationTypeName}SelectionFields
                                     >,
-                                "${MutationTypeName}",
                                 "${MutationTypeName}Selection",
                                 "${MutationTypeName}",
+                                "${MutationTypeName}",
                                 0,
-                                { $lazy: () => "T" },
-                                "$lazy"
                             >
                         >;`
                         : ""
@@ -758,12 +754,10 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                                         ReturnType<typeof make${SubscriptionTypeName}SelectionInput>,
                                         ${SubscriptionTypeName}SelectionFields
                                     >,
-                                "${SubscriptionTypeName}",
                                 "${SubscriptionTypeName}Selection",
                                 "${SubscriptionTypeName}",
+                                "${SubscriptionTypeName}",
                                 0,
-                                { $lazy: () => "T" },
-                                "$lazy"
                             >
                         >;`
                         : ""

--- a/src/lib/codegen/flavors/default/generator-flavor.ts
+++ b/src/lib/codegen/flavors/default/generator-flavor.ts
@@ -228,7 +228,7 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                     >
                 >
                 : ToTArrayWithDepth<
-                {
+                    {
                         [K in keyof TT]: TT[K] extends SelectionWrapperImpl<
                             infer FN,
                             infer TN,
@@ -696,12 +696,12 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                             (field) =>
                                 [
                                     field,
-                            this.makeSelectionFunctionInputObjectValueForField(
-                                field,
+                                    this.makeSelectionFunctionInputObjectValueForField(
+                                        field,
                                         this.typeMeta.isInput
                                             ? []
                                             : [this.typeName],
-                            ),
+                                    ),
                                 ] as const,
                         )
                         .map(([field, fieldSlfn]) =>
@@ -878,7 +878,11 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                 const _result = new SelectionWrapper(undefined, undefined, undefined, undefined, r, root, undefined) as unknown as T;
                 Object.keys(r).forEach((key) => (_result as T)[key as keyof T]);
                 const result = _result as {
-                    [k in keyof T]: Omit<T[k], "$lazy">;
+                    [k in keyof T]: T[k] extends (...args: infer A) => any ? (...args: A) => Omit<
+                        ReturnType<T[k]>, "$lazy"
+                    > : Omit<
+                        T[k], "$lazy"
+                    >
                 };
                 type TR = typeof result;
                 

--- a/src/lib/codegen/flavors/default/generator-flavor.ts
+++ b/src/lib/codegen/flavors/default/generator-flavor.ts
@@ -699,16 +699,15 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
     }
 
     public static makeRootOperationFunction(
-        schema: GraphQLSchema,
         collector: Collector,
         authConfig?: {
             headerName: string;
         },
     ): string {
         // get the root operation types
-        const QueryTypeName = schema.getQueryType()?.name;
-        const MutationTypeName = schema.getMutationType()?.name;
-        const SubscriptionTypeName = schema.getSubscriptionType()?.name;
+        const QueryTypeName = collector.QueryTypeName;
+        const MutationTypeName = collector.MutationTypeName;
+        const SubscriptionTypeName = collector.SubscriptionTypeName;
 
         const rootOperationFunction = `
             export type _RootOperationSelectionFields<T extends object> = {


### PR DESCRIPTION
This PR implements the `Lazy Queries` and `Lazy Mutations` features.

## Use cases / requirements
Using the generated client to execute queries and mutations is nice and doing so always in direct manner may be useful and sufficient in many cases but GraphQL - especially in a frontend context - thrives by defining queries and mutations once and reusing them all over your application.

In Samarium's context this would mean that the defined operations need to defer their executions and instead of having the returned result from the server with the appropriate type instantly after `await`, the returned values from the client root function need to be async functions themselves which on execution will send the operation to the server.
Also one would expect to be able to pass query/mutation arguments to the function.

## Implementation
To make this as easy as possible for the user, a magic `$lazy` property is added to the Query/Mutation/Subscription Operation Type fields. This way you can define your operation as usual and in the end decide whether it should be a lazy operation or not.

### Full example:
```typescript
import unions from "./unions6";

const { all, books } = await unions((op) =>
    op.query((s) => ({
        all: s.search({ title: "default title" })(({ $on }) => ({
            ...$on.Book((s) => ({
                ...s.$scalars(),
            })),
            ...$on.Article((s) => ({
                ...s.$scalars(),
                dice: s.rollDice({ numDice: 3, numSides: 6 }),
            })),
        })).$lazy, // <--- return the $lazy prop
        books: s.books((s) => ({
            title: s.title,
        })).$lazy, // <--- return the $lazy prop
    })),
);

const defaultSearches = await all({});
console.log(defaultSearches.map((a) => a.title));

const defaultBooks = await books();
console.log(defaultBooks.map((a) => a.title));

const testSearches = await all({ title: "test" });
console.log(testSearches.map((a) => a.title));

const test2Searches = await all({ title: "221234" });
console.log(test2Searches.map((a) => a.title));
```

### Explanation
Each field from the Query root type has the `$lazy` property which is accessed after defining your selection.
You can pass arguments to your selection and these will serve as default arguments later on.

Now, instead of being executed and sent to the server, an async function is returned for every lazy operation.

These functions can now be called and awaited later in the code and arguments passed to it will be merged with the given default arguments in the original definition of the operation.

That's it. Your operations are now async typescript functions you can use anywhere in your code! 🎉 

**You can also mix instant and lazy operations!**