### PR TITLE
Add GraphQL (client) directives support

### DIFF
--- a/src/lib/codegen/builder/collector.ts
+++ b/src/lib/codegen/builder/collector.ts
@@ -1,3 +1,4 @@
+import type { DirectiveMeta } from "../types/meta";
 import { type TypeMeta } from "./meta";
 
 /**
@@ -93,6 +94,24 @@ export class Collector<
     }
     public getArgumentMeta(typeName: string): string {
         return this._argumentMeta.get(typeName)!;
+    }
+
+    /**
+     * Collect generated code for a given type.
+     * In this case, the generated Directive types.
+     */
+    private _directivesFunctions: Map<DirectiveMeta, string> = new Map();
+    get directivesFunctions(): Map<DirectiveMeta, string> {
+        return this._directivesFunctions;
+    }
+    public addDirectiveFunction(meta: DirectiveMeta, code: string): void {
+        this._directivesFunctions.set(meta, code);
+    }
+    public hasDirectiveFunction(meta: DirectiveMeta): boolean {
+        return this._directivesFunctions.has(meta);
+    }
+    public getDirectiveFunction(meta: DirectiveMeta): string {
+        return this._directivesFunctions.get(meta)!;
     }
 
     /**

--- a/src/lib/codegen/builder/generator.ts
+++ b/src/lib/codegen/builder/generator.ts
@@ -1,5 +1,5 @@
 import prettier from "prettier";
-import { GraphQLSchema } from "graphql";
+import { DirectiveLocation, GraphQLSchema } from "graphql";
 import { type CodegenOptions, gatherMeta } from "./meta";
 import { Collector } from "./collector";
 
@@ -52,9 +52,29 @@ export class Generator {
             if (!typeMeta.isInput) continue;
             new this.Codegen(typeName, collector, options).makeSelectionType();
         }
+        // Generate directives
+        for (const [typeName, typeMeta] of collector.types.entries()) {
+            if (
+                !typeMeta.isDirective?.locations.some((l) =>
+                    [
+                        DirectiveLocation.FIELD,
+                        DirectiveLocation.FRAGMENT_SPREAD,
+                        DirectiveLocation.INLINE_FRAGMENT,
+                    ].includes(l),
+                )
+            )
+                continue;
+            new this.Codegen(typeName, collector, options).makeDirective();
+        }
+
         // Generate selection types for all types
         for (const [typeName, typeMeta] of collector.types.entries()) {
-            if (typeMeta.isScalar || typeMeta.isInput || typeMeta.isEnum)
+            if (
+                typeMeta.isScalar ||
+                typeMeta.isInput ||
+                typeMeta.isEnum ||
+                typeMeta.isDirective
+            )
                 continue;
             new this.Codegen(typeName, collector, options).makeSelectionType();
             new this.Codegen(
@@ -86,6 +106,9 @@ export class Generator {
                     ([type]) => !type.isScalar && !type.isEnum && !type.isInput,
                 )
                 .map(([_, code]) => code),
+            ...[...collector.directivesFunctions.entries()].map(
+                ([_, code]) => code,
+            ),
             this.Codegen.makeRootOperationFunction(collector, authConfig),
         ].join("\n");
 

--- a/src/lib/codegen/builder/generator.ts
+++ b/src/lib/codegen/builder/generator.ts
@@ -78,7 +78,7 @@ export class Generator {
                 .map(([_, code]) => code)
                 .filter((code, index, arr) => arr.indexOf(code) === index),
             ...[...collector.selectionTypes.entries()]
-                .filter(([type]) => !type.isScalar && !type.isEnum)
+                .filter(([type]) => type.isInput)
                 .map(([_, code]) => code)
                 .filter((code, index, arr) => arr.indexOf(code) === index),
             ...[...collector.selectionFunctions.entries()]

--- a/src/lib/codegen/flavors/default/generator-flavor.ts
+++ b/src/lib/codegen/flavors/default/generator-flavor.ts
@@ -761,19 +761,12 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                     ${helperFunctions}
                 } as const;
             };
-            export const ${selectionFunctionName} = (makeSLFN as SLFN<
-                    {},
-                    ReturnType<typeof make${selectionFunctionName}Input>,
-                    "${selectionFunctionName}",
-                    "${this.typeName}",
-                    "${this.originalFullTypeName.replaceAll("[", "").replaceAll("]", "").replaceAll("!", "")}",
-                    ${this.typeMeta.isList ?? 0}
-                >)(
-                    ${`make${selectionFunctionName}Input`},
-                    "${selectionFunctionName}",
-                    "${this.typeName}",
-                    "${this.originalFullTypeName.replaceAll("[", "").replaceAll("]", "").replaceAll("!", "")}",
-                    ${this.typeMeta.isList ?? 0}
+            export const ${selectionFunctionName} = makeSLFN(
+                ${`make${selectionFunctionName}Input`},
+                "${selectionFunctionName}",
+                "${this.typeName}",
+                "${this.originalFullTypeName.replaceAll("[", "").replaceAll("]", "").replaceAll("!", "")}",
+                ${this.typeMeta.isList ?? 0}
             );
         `;
         this.collector.addSelectionFunction(
@@ -814,51 +807,6 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
         const SubscriptionTypeName = collector.SubscriptionTypeName;
 
         const rootOperationFunction = `
-            export type _RootOperationSelectionFields<T extends object> = {
-                ${
-                    QueryTypeName && collector.types.has(QueryTypeName)
-                        ? `query: ReturnType<
-                            SLFN<
-                                T, 
-                                ReturnType<typeof make${QueryTypeName}SelectionInput>,
-                                "${QueryTypeName}Selection",
-                                "${QueryTypeName}",
-                                "${QueryTypeName}",
-                                0,
-                            >
-                        >;`
-                        : ""
-                }
-                ${
-                    MutationTypeName && collector.types.has(MutationTypeName)
-                        ? `mutation: ReturnType<
-                            SLFN<
-                                T, 
-                                ReturnType<typeof make${MutationTypeName}SelectionInput>,
-                                "${MutationTypeName}Selection",
-                                "${MutationTypeName}",
-                                "${MutationTypeName}",
-                                0,
-                            >
-                        >;`
-                        : ""
-                }
-                ${
-                    SubscriptionTypeName &&
-                    collector.types.has(SubscriptionTypeName)
-                        ? `subscription: ReturnType<
-                            SLFN<
-                                T, 
-                                ReturnType<typeof make${SubscriptionTypeName}SelectionInput>,
-                                "${SubscriptionTypeName}Selection",
-                                "${SubscriptionTypeName}",
-                                "${SubscriptionTypeName}",
-                                0,
-                            >
-                        >;`
-                        : ""
-                }
-            };
             export function _makeRootOperationInput(this: any) {
                 return {
                     ${
@@ -901,7 +849,7 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
             }
             function __client__ <
                 T extends object,
-                F extends _RootOperationSelectionFields<T>>(
+                F extends ReturnType<typeof _makeRootOperationInput>>(
                 this: any, 
                 s: (selection: F) => T
             ) {

--- a/src/lib/codegen/flavors/default/generator-flavor.ts
+++ b/src/lib/codegen/flavors/default/generator-flavor.ts
@@ -653,6 +653,10 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
             );
         }
 
+        const typeHasScalars = this.typeMeta.fields.some(
+            (f) => f.type.isScalar || f.type.isEnum,
+        );
+
         let helperFunctions = "";
         if (this.typeMeta.isUnion) {
             helperFunctions = `
@@ -678,13 +682,18 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                     fieldName: "",
                     isFragment: f.name,
                 }) as ((...args: ArgumentsTypeFromFragment<F>) => ReturnTypeFromFragment<F>),
+            ${
+                typeHasScalars
+                    ? `
             $scalars: () =>
                 selectScalars(
                         make${selectionFunctionName}Input.bind(this)(),
                     ) as SLWsFromSelection<
                         ReturnType<typeof make${selectionFunctionName}Input>
                     >,
-            `;
+            `
+                    : ""
+            }`;
         }
         const makeSelectionFunctionInputReturnTypeParts = new Map<
             string,
@@ -784,7 +793,13 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
                 ) => (
                     ...args: ArgumentsTypeFromFragment<F>
                 ) => ReturnTypeFromFragment<F>;
+                ${
+                    typeHasScalars
+                        ? `
                 $scalars: () => SLWsFromSelection<ReturnType<typeof ${`make${selectionFunctionName}Input`}>>;
+                `
+                        : ""
+                }
             };`
                     : ""
             }

--- a/src/lib/codegen/types/meta.ts
+++ b/src/lib/codegen/types/meta.ts
@@ -1,3 +1,5 @@
+import type { DirectiveLocation } from "graphql";
+
 export type Maybe<T> = null | undefined | T;
 export enum Operation {
     Query = "query",
@@ -27,6 +29,8 @@ export interface RootFieldMeta {
 }
 export interface SchemaMeta {
     types: TypeMeta[];
+    directives: DirectiveMeta[];
+
     query: RootFieldMeta[];
     mutation: RootFieldMeta[];
     subscription: RootFieldMeta[];
@@ -70,4 +74,13 @@ export interface TypeMeta {
     enumValues: EnumValueMeta[];
     inputFields: ArgumentMeta[];
     ofType?: TypeMeta;
+
+    isDirective?: DirectiveMeta;
+}
+
+export interface DirectiveMeta {
+    name: string;
+    description: Maybe<string>;
+    locations: DirectiveLocation[];
+    args: ArgumentMeta[];
 }


### PR DESCRIPTION
This PR implements the GraphQL directives feature.
In particular client-directives are supported, as samarium is a client generation tool.

## Client Directives
GraphQL specifies `@skip` and `@include` as client directives by default.
In the context of this library, these directives are not really needed, as one can build queries and selections conditionally with code and there's no need for writing queries with string interpolations and conditions - which is what these directives mainly aim to circumvent. It may still be helpful, to have such a directive in your fragment!

Also, this implementation enables the use of any other client directive that may be defined in your schema.

## Reduced Output Size
Compared to `v0.8.1` the generated output is now **14% smaller** (tested with SpaceX's api), despite adding the new features. Unused type definitions were removed while all types remain the same. Many types are now inferred and respect Custom Scalar types.