### PR TITLE
Collect Custom Scalars from GQL Schema & generate code and types for them

### DIFF
--- a/packages/make/src/graphql/builder/__tests__/generator.test.ts
+++ b/packages/make/src/graphql/builder/__tests__/generator.test.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+import { describe, it } from "bun:test";
+
+import { GeneratorSelectionTypeFlavorDefault } from "../../flavors/default/generator-flavor";
+import { Generator } from "../generator";
+import { introspectGraphQLSchema } from "./util";
+
+describe.only("generate", () => {
+    // it("should generate code", async () => {
+    //     const schema = await introspectGraphQLSchema(
+    //         "http://localhost:4000/graphql",
+    //     );
+    //     const generator = new Generator(GeneratorSelectionTypeFlavorDefault);
+    //     const code = await generator.generate({
+    //         schema,
+    //         options: {},
+    //     });
+    //     fs.writeFileSync("./code.ts", code);
+    // });
+});

--- a/packages/make/src/graphql/builder/__tests__/meta.test.ts
+++ b/packages/make/src/graphql/builder/__tests__/meta.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from "bun:test";
-import { gatherMeta, gatherMetaForType } from "./meta";
+import { gatherMeta, gatherMetaForType } from "../meta";
 import {
     GraphQLSchema,
     GraphQLObjectType,
@@ -7,21 +7,18 @@ import {
     GraphQLNonNull,
     GraphQLString,
 } from "graphql";
-import { Collector } from "./collector";
-// import { introspectGraphQLSchema } from "@/commands/util/introspect";
+import { Collector } from "../collector";
+import { introspectGraphQLSchema } from "./util";
 
 describe("gatherMetaForType", () => {
     // it("should gather meta for a whole schema", async () => {
     //     // Arrange
     //     const schema = await introspectGraphQLSchema(
-    //         "https://spacex-production.up.railway.app/graphql",
+    //         "http://localhost:4000/graphql",
     //     );
+    //     const collector = new Collector("Query", "Mutation", "Subscription");
     //     // Act
-    //     const meta = gatherMeta(
-    //         schema,
-    //         {},
-    //         new Collector("Query", "Mutation", "Subscription"),
-    //     );
+    //     const meta = gatherMeta(schema, {}, collector);
 
     //     console.log(meta);
     // });
@@ -44,11 +41,12 @@ describe("gatherMetaForType", () => {
                 },
             }),
         });
+        const collector = new Collector("Query", "Mutation", "Subscription");
 
         const type = schema.getType("User");
 
         // Act
-        const meta = gatherMetaForType(schema, type!, {});
+        const meta = gatherMetaForType(schema, type!, {}, collector);
 
         // Assert
         expect(meta.isObject).toBe(true);
@@ -77,11 +75,12 @@ describe("gatherMetaForType", () => {
                 },
             }),
         });
+        const collector = new Collector("Query", "Mutation", "Subscription");
 
         const type = schema.getType("User");
 
         // Act
-        const meta = gatherMetaForType(schema, type!, {});
+        const meta = gatherMetaForType(schema, type!, {}, collector);
 
         // Assert
         expect(meta.isInterface).toBe(true);

--- a/packages/make/src/graphql/builder/__tests__/util.ts
+++ b/packages/make/src/graphql/builder/__tests__/util.ts
@@ -1,0 +1,36 @@
+import { GraphQLSchema, type IntrospectionQuery } from "graphql";
+import { getIntrospectionQuery, buildClientSchema } from "graphql";
+import { GraphQLClient } from "graphql-request";
+
+/**
+ * Introspects a GraphQL service using 'graphql-request' and returns a GraphQLSchema object.
+ *
+ * @param endpoint The GraphQL endpoint URL.
+ * @returns A Promise that resolves to the GraphQLSchema object.
+ */
+export async function introspectGraphQLSchema(
+    endpoint: string,
+    headers?: string[],
+): Promise<GraphQLSchema> {
+    try {
+        // Create a GraphQL client with the 'graphql-request' library
+        const client = new GraphQLClient(endpoint);
+
+        // Send the introspection query using the client
+        const introspectionResult = await client.request<IntrospectionQuery>(
+            getIntrospectionQuery(),
+            undefined,
+            new Headers(
+                headers?.map((header) => header.split("=") as [string, string]),
+            ),
+        );
+
+        // Build a GraphQLSchema object from the introspection result
+        const schema = buildClientSchema(introspectionResult);
+
+        return schema;
+    } catch (error: any) {
+        // throw the error to the caller
+        throw error;
+    }
+}

--- a/packages/make/src/graphql/builder/base.ts
+++ b/packages/make/src/graphql/builder/base.ts
@@ -24,7 +24,7 @@ export abstract class GeneratorSelectionTypeFlavor {
      * The code for the helper types.
      * The helper types are types that are used by the selection type flavor.
      */
-    public static readonly HelperTypes: string;
+    public static readonly HelperTypes: (customScalars: TypeMeta[]) => string;
 
     /**
      * The code for the helper functions.

--- a/packages/make/src/graphql/builder/collector.ts
+++ b/packages/make/src/graphql/builder/collector.ts
@@ -41,6 +41,26 @@ export class Collector<
     }
 
     /**
+     * The collected custom scalars.
+     */
+    private _customScalars: Map<string, TypeMeta> = new Map();
+    get customScalars(): Map<string, TypeMeta> {
+        return this._customScalars;
+    }
+    public addCustomScalar(type: TypeMeta): void {
+        this._customScalars.set(type.name, type);
+    }
+    public hasCustomScalar(typeName: string): boolean {
+        return this._customScalars.has(typeName);
+    }
+    public getCustomScalar(typeName: string): TypeMeta {
+        return this._customScalars.get(typeName)!;
+    }
+    public removeCustomScalar(typeName: string): void {
+        this._customScalars.delete(typeName);
+    }
+
+    /**
      * Collect generated code for a given type.
      * In this case, the generated Enum types.
      */

--- a/packages/make/src/graphql/builder/generator.ts
+++ b/packages/make/src/graphql/builder/generator.ts
@@ -99,7 +99,11 @@ export class Generator {
                 .map(([_, code]) => code)
                 .filter((code, index, arr) => arr.indexOf(code) === index),
             ...[...collector.selectionTypes.entries()]
-                .filter(([type]) => type.isInput)
+                .filter(
+                    ([type]) =>
+                        type.isInput ||
+                        (collector.customScalars.size > 0 && type.isObject),
+                )
                 .map(([_, code]) => code)
                 .filter((code, index, arr) => arr.indexOf(code) === index),
             this.Codegen.EnumTypesMapped(collector),

--- a/packages/make/src/graphql/builder/generator.ts
+++ b/packages/make/src/graphql/builder/generator.ts
@@ -85,7 +85,9 @@ export class Generator {
 
         const code = [
             this.Codegen.FieldValueWrapperType,
-            this.Codegen.HelperTypes,
+            this.Codegen.HelperTypes(
+                Array.from(collector.customScalars.values()),
+            ),
             this.Codegen.HelperFunctions,
             ...[...collector.enumsTypes.entries()]
                 .map(([_, code]) => code)

--- a/packages/make/src/graphql/builder/meta.ts
+++ b/packages/make/src/graphql/builder/meta.ts
@@ -162,7 +162,7 @@ export const gatherMetaForRootField = (
 ): RootFieldMeta => {
     const meta: RootFieldMeta = {
         name: rootField.name,
-        description: rootField.description,
+        description: rootField.description ?? undefined,
         operation,
         args: [],
         type: gatherMetaForType(schema, rootField.type, options, collector),
@@ -195,7 +195,7 @@ export const gatherMetaForArgument = (
         // TODO: remove hack
         hasArgs: false,
         args: [],
-        description: arg.description,
+        description: arg.description ?? undefined,
         type: gatherMetaForType(schema, arg.type, options, collector),
     };
 };
@@ -217,7 +217,7 @@ export const gatherMetaForType = (
 
     const meta: TypeMeta = {
         name: type.toString(),
-        description: namedType.description,
+        description: namedType.description ?? undefined,
         isList: type.toString().split("[").length - 1,
         isNonNull: type.toString().endsWith("!"),
         isScalar: namedType instanceof GraphQLScalarType,
@@ -250,7 +250,7 @@ export const gatherMetaForType = (
         for (const enumValue of (namedType as GraphQLEnumType).getValues()) {
             meta.enumValues.push({
                 name: enumValue.name,
-                description: enumValue.description,
+                description: enumValue.description ?? undefined,
             });
         }
     }
@@ -338,7 +338,7 @@ export const gatherMetaForField = (
 ): FieldMeta => {
     const meta: FieldMeta = {
         name: field.name,
-        description: field.description,
+        description: field.description ?? undefined,
         hasArgs: Object.keys(field.args).length > 0,
         args: [],
         type: gatherMetaForType(schema, field.type, options, collector),
@@ -368,7 +368,7 @@ export const gatherMetaForDirective = (
 ): DirectiveMeta => {
     const meta: DirectiveMeta = {
         name: directive.name,
-        description: directive.description,
+        description: directive.description ?? undefined,
         locations: directive.locations as DirectiveLocation[],
         args: [],
     };
@@ -381,7 +381,7 @@ export const gatherMetaForDirective = (
 
     collector.addType({
         name: `Directive_${directive.name}`,
-        description: directive.description,
+        description: directive.description ?? undefined,
         isList: 0,
         isNonNull: false,
         isScalar: false,

--- a/packages/make/src/graphql/builder/meta.ts
+++ b/packages/make/src/graphql/builder/meta.ts
@@ -148,6 +148,7 @@ export const gatherMeta = (
             );
         }
     }
+    const hasCollectedCustomScalars = collector.customScalars.size > 0;
 
     const queryType = schema.getQueryType();
     if (queryType) {
@@ -217,7 +218,7 @@ export const gatherMeta = (
         const type = schema.getTypeMap()[typeName];
         if (
             isObjectType(type) ||
-            isInputObjectType(type) ||
+            (hasCollectedCustomScalars && isInputObjectType(type)) ||
             isInterfaceType(type)
         ) {
             meta.types.push(

--- a/packages/make/src/graphql/builder/meta.ts
+++ b/packages/make/src/graphql/builder/meta.ts
@@ -51,7 +51,7 @@ export {
 export const gatherMeta = (
     schema: GraphQLSchema,
     options: CodegenOptions,
-    collector?: Collector,
+    collector: Collector,
 ): SchemaMeta => {
     const meta: SchemaMeta = {
         types: [],
@@ -158,7 +158,7 @@ export const gatherMetaForRootField = (
     rootField: GraphQLField<any, any>,
     operation: Operation,
     options: CodegenOptions,
-    collector?: Collector,
+    collector: Collector,
 ): RootFieldMeta => {
     const meta: RootFieldMeta = {
         name: rootField.name,
@@ -188,7 +188,7 @@ export const gatherMetaForArgument = (
     schema: GraphQLSchema,
     arg: GraphQLArgument,
     options: CodegenOptions,
-    collector?: Collector,
+    collector: Collector,
 ): ArgumentMeta => {
     return {
         name: arg.name,
@@ -211,7 +211,7 @@ export const gatherMetaForType = (
     schema: GraphQLSchema,
     type: GraphQLType,
     options: CodegenOptions,
-    collector?: Collector,
+    collector: Collector,
 ): TypeMeta => {
     const namedType = getNamedType(type);
 
@@ -236,10 +236,10 @@ export const gatherMetaForType = (
     };
 
     // Handle already processed types
-    if (collector?.hasType(meta.name)) {
+    if (collector.hasType(meta.name)) {
         return collector.getType(meta.name);
     } else {
-        collector?.addType(meta);
+        collector.addType(meta);
     }
 
     meta.ofType = meta;
@@ -318,9 +318,7 @@ export const gatherMetaForType = (
         }
     }
 
-    if (collector) {
-        collector.addType(meta);
-    }
+    collector.addType(meta);
 
     return meta;
 };
@@ -336,7 +334,7 @@ export const gatherMetaForField = (
     schema: GraphQLSchema,
     field: GraphQLField<any, any>,
     options: CodegenOptions,
-    collector?: Collector,
+    collector: Collector,
 ): FieldMeta => {
     const meta: FieldMeta = {
         name: field.name,
@@ -366,7 +364,7 @@ export const gatherMetaForDirective = (
     schema: GraphQLSchema,
     directive: GraphQLDirective,
     options: CodegenOptions,
-    collector?: Collector,
+    collector: Collector,
 ): DirectiveMeta => {
     const meta: DirectiveMeta = {
         name: directive.name,
@@ -381,29 +379,27 @@ export const gatherMetaForDirective = (
         meta.args.push(gatherMetaForArgument(schema, arg, options, collector));
     }
 
-    if (collector) {
-        collector.addType({
-            name: `Directive_${directive.name}`,
-            description: directive.description,
-            isList: 0,
-            isNonNull: false,
-            isScalar: false,
-            isEnum: false,
-            isInput: false,
-            isInterface: false,
-            isObject: false,
-            isUnion: false,
-            isQuery: false,
-            isMutation: false,
-            isSubscription: false,
-            fields: [],
-            possibleTypes: [],
-            enumValues: [],
-            inputFields: [],
+    collector.addType({
+        name: `Directive_${directive.name}`,
+        description: directive.description,
+        isList: 0,
+        isNonNull: false,
+        isScalar: false,
+        isEnum: false,
+        isInput: false,
+        isInterface: false,
+        isObject: false,
+        isUnion: false,
+        isQuery: false,
+        isMutation: false,
+        isSubscription: false,
+        fields: [],
+        possibleTypes: [],
+        enumValues: [],
+        inputFields: [],
 
-            isDirective: meta,
-        });
-    }
+        isDirective: meta,
+    });
 
     return meta;
 };

--- a/packages/make/src/graphql/builder/meta.ts
+++ b/packages/make/src/graphql/builder/meta.ts
@@ -19,6 +19,7 @@ import {
     isInterfaceType,
     type GraphQLDirective,
     type DirectiveLocation,
+    isInputObjectType,
 } from "graphql";
 import { Collector } from "./collector";
 
@@ -214,7 +215,11 @@ export const gatherMeta = (
         }
 
         const type = schema.getTypeMap()[typeName];
-        if (isObjectType(type) || isInterfaceType(type)) {
+        if (
+            isObjectType(type) ||
+            isInputObjectType(type) ||
+            isInterfaceType(type)
+        ) {
             meta.types.push(
                 gatherMetaForType(schema, type, options, collector),
             );

--- a/packages/make/src/graphql/builder/meta.ts
+++ b/packages/make/src/graphql/builder/meta.ts
@@ -48,11 +48,16 @@ const createACustomScalarType = (
     scalarTSType: string,
     collector: Collector<any, any, any>,
 ): TypeMeta => {
+    const descriptionIncludesTypedef = description?.includes("@typedef");
+    const typeFromTypedef = descriptionIncludesTypedef
+        ? description?.match(/@typedef\s*{(.*)}/)?.[1]
+        : undefined;
+
     const meta: TypeMeta = {
         name,
         description,
         isScalar: true,
-        scalarTSType,
+        scalarTSType: typeFromTypedef ?? scalarTSType,
         isEnum: false,
         isObject: false,
         isUnion: false,

--- a/packages/make/src/graphql/builder/meta.ts
+++ b/packages/make/src/graphql/builder/meta.ts
@@ -103,7 +103,7 @@ export const gatherMeta = (
         subscription: [],
     };
 
-    // Gather meta for each type
+    // Gather meta for custom scalars first
     for (const typeName in schema.getTypeMap()) {
         if (!options.includeSchemaDefinition) {
             if (

--- a/packages/make/src/graphql/flavors/default/generator-flavor.ts
+++ b/packages/make/src/graphql/flavors/default/generator-flavor.ts
@@ -560,7 +560,7 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
             ? this.originalTypeNameToTypescriptTypeNameWithoutModifiers(
                   this.originalFullTypeName,
               )
-            : `${this.typeName}SelectionFields`;
+            : this.typeName;
 
         if (this.collector.hasSelectionType(this.typeMeta)) {
             return selectionTypeName;
@@ -570,9 +570,8 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
 
         if (this.typeMeta.isUnion) {
             const types = this.typeMeta.possibleTypes
-                .map(
-                    (t) =>
-                        `${this.originalTypeNameToTypescriptFriendlyName(t.name)}SelectionFields`,
+                .map((t) =>
+                    this.originalTypeNameToTypescriptFriendlyName(t.name),
                 )
                 .join(" | ");
 

--- a/packages/make/src/graphql/flavors/default/generator-flavor.ts
+++ b/packages/make/src/graphql/flavors/default/generator-flavor.ts
@@ -100,8 +100,13 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
         ["Time", "Date"],
         ["JSON", "Record<string, any>"],
     ]);
-    public ScalarTypeMap: Map<string, string> =
-        GeneratorSelectionTypeFlavorDefault.ScalarTypeMap;
+    public ScalarTypeMap: () => Map<string, string> = () =>
+        new Map([
+            ...[...GeneratorSelectionTypeFlavorDefault.ScalarTypeMap.entries()],
+            // ...[...this.collector.customScalars.values()].map(
+            //     (cs) => [cs.name, cs.scalarTSType!] as const,
+            // ),
+        ]);
 
     public static readonly FieldValueWrapperType = wrapperCode;
 
@@ -120,8 +125,10 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
         };`;
     };
 
-    public static readonly HelperTypes = `
-    export interface ScalarTypeMapWithCustom {};
+    public static readonly HelperTypes = (customScalars: TypeMeta[]) => `
+    export interface ScalarTypeMapWithCustom {
+        ${customScalars.map((cs) => `"${cs.name}": ${cs.scalarTSType};`).join("\n")}
+    }
     export interface ScalarTypeMapDefault {
         ${Array.from(GeneratorSelectionTypeFlavorDefault.ScalarTypeMap)
             .map(([k, v]) => `"${k}": ${v};`)
@@ -388,13 +395,28 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
         fieldName: string,
         fieldMeta: TypeMeta,
     ): string {
-        const type =
-            this.ScalarTypeMap.get(
-                fieldMeta.name
-                    .replaceAll("!", "")
-                    .replaceAll("[", "")
-                    .replaceAll("]", ""),
-            ) ?? "any";
+        let type = "";
+
+        if (fieldMeta.isEnum) {
+            type = fieldMeta
+                .ofType!.name.replaceAll("!", "")
+                .replaceAll("[", "")
+                .replaceAll("]", "");
+        } else {
+            type =
+                this.ScalarTypeMap().get(
+                    fieldMeta.name
+                        .replaceAll("!", "")
+                        .replaceAll("[", "")
+                        .replaceAll("]", ""),
+                ) ??
+                (fieldMeta.scalarTSType
+                    ? `ScalarTypeMapWithCustom["${fieldMeta.name
+                          .replaceAll("!", "")
+                          .replaceAll("[", "")
+                          .replaceAll("]", "")}"]`
+                    : "any");
+        }
 
         if (fieldMeta.isList) {
             return `${Array.from({ length: fieldMeta.isList })
@@ -419,6 +441,7 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
             const argsTypeName = `${parents.join()}${field.name
                 .slice(0, 1)
                 .toUpperCase()}${field.name.slice(1)}Args`;
+
             if (!this.collector.hasArgumentType(argsTypeName)) {
                 const argsTypeBody = field.args
                     .map((arg) => {
@@ -431,10 +454,17 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
 
                         let argType = "any";
                         if (isScalar) {
-                            argType =
-                                this.ScalarTypeMap.get(
-                                    arg.type.name.replaceAll("!", ""),
-                                ) ?? "any";
+                            argType = arg.type.scalarTSType
+                                ? `ScalarTypeMapWithCustom["${arg.type.name
+                                      .replaceAll("!", "")
+                                      .replaceAll("[", "")
+                                      .replaceAll("]", "")}"]`
+                                : this.ScalarTypeMap().get(
+                                      arg.type.name
+                                          .replaceAll("!", "")
+                                          .replaceAll("[", "")
+                                          .replaceAll("]", ""),
+                                  ) ?? "any";
                         } else if (isInput || isEnum) {
                             argType = this.originalTypeNameToTypescriptTypeName(
                                 arg.type.name,
@@ -676,10 +706,17 @@ export class GeneratorSelectionTypeFlavorDefault extends GeneratorSelectionTypeF
 
                     let argType = "any";
                     if (isScalar) {
-                        argType =
-                            this.ScalarTypeMap.get(
-                                arg.type.name.replaceAll("!", ""),
-                            ) ?? "any";
+                        argType = arg.type.scalarTSType
+                            ? `ScalarTypeMapWithCustom["${arg.type.name
+                                  .replaceAll("!", "")
+                                  .replaceAll("[", "")
+                                  .replaceAll("]", "")}"]`
+                            : this.ScalarTypeMap().get(
+                                  arg.type.name
+                                      .replaceAll("!", "")
+                                      .replaceAll("[", "")
+                                      .replaceAll("]", ""),
+                              ) ?? "any";
                     } else if (isInput || isEnum) {
                         argType = this.originalTypeNameToTypescriptTypeName(
                             arg.type.name,

--- a/packages/make/src/graphql/flavors/default/wrapper.ts
+++ b/packages/make/src/graphql/flavors/default/wrapper.ts
@@ -367,7 +367,7 @@ export class OperationSelectionCollector {
                 depth,
                 RootOperation[OPTIONS].scalars[
                     type as keyof (typeof RootOperation)[typeof OPTIONS]["scalars"]
-                ],
+                ] ?? ((value: string) => JSON.parse(value)),
             ) as T;
         }
 

--- a/packages/make/src/graphql/types/meta.ts
+++ b/packages/make/src/graphql/types/meta.ts
@@ -60,6 +60,7 @@ export interface TypeMeta {
     isList: number;
     isNonNull: boolean;
     isScalar: boolean;
+    scalarTSType?: string;
     isEnum: boolean;
     isInput: boolean;
     isInterface: boolean;

--- a/packages/make/src/graphql/types/meta.ts
+++ b/packages/make/src/graphql/types/meta.ts
@@ -1,6 +1,5 @@
 import type { DirectiveLocation } from "graphql";
 
-export type Maybe<T> = null | undefined | T;
 export enum Operation {
     Query = "query",
     Mutation = "mutation",
@@ -22,7 +21,7 @@ export interface CodegenOptions {
 }
 export interface RootFieldMeta {
     name: string;
-    description: Maybe<string>;
+    description?: string;
     operation: Operation;
     args: ArgumentMeta[];
     type: TypeMeta;
@@ -38,7 +37,7 @@ export interface SchemaMeta {
 
 export interface FieldMeta {
     name: string;
-    description: Maybe<string>;
+    description?: string;
     hasArgs: boolean;
     args: ArgumentMeta[];
     type: TypeMeta;
@@ -48,16 +47,16 @@ export interface ArgumentMeta extends FieldMeta {
     // TOOO: remove hack
     hasArgs: false;
     args: [];
-    description: Maybe<string>;
+    description?: string;
     type: TypeMeta;
 }
 export interface EnumValueMeta {
     name: string;
-    description: Maybe<string>;
+    description?: string;
 }
 export interface TypeMeta {
     name: string;
-    description: Maybe<string>;
+    description?: string;
     isList: number;
     isNonNull: boolean;
     isScalar: boolean;
@@ -80,7 +79,7 @@ export interface TypeMeta {
 
 export interface DirectiveMeta {
     name: string;
-    description: Maybe<string>;
+    description?: string;
     locations: DirectiveLocation[];
     args: ArgumentMeta[];
 }

--- a/packages/make/src/openapi/builder/__tests__/meta.test.ts
+++ b/packages/make/src/openapi/builder/__tests__/meta.test.ts
@@ -16,13 +16,10 @@ describe.only("gatherMetaForType", () => {
         const collector = new Collector();
         const schemaMeta = gatherMeta(schema, {}, collector);
 
-        fs.writeFileSync(
-            "./schemaMeta.ts",
-            `export default ${inspect(schemaMeta, { depth: 10 })
-                .replace(/\.\.\. .* more items/gm, "")
-                .replace(/<ref .*>/g, "")
-                .replace(/\[Circular .*\]/g, '"Circular"')
-                .replace(/\n/g, "")}`,
-        );
+        const str = `export default ${inspect(schemaMeta, { depth: 10 })
+            .replace(/\.\.\. .* more items/gm, "")
+            .replace(/<ref .*>/g, "")
+            .replace(/\[Circular .*\]/g, '"Circular"')
+            .replace(/\n/g, "")}`;
     });
 });


### PR DESCRIPTION
This PR finalizes the Custom Scalar capabilities, as it truly accounts for any arbitrary custom scalars defined in the GraphQL schema.

Previously only a set of common predefined scalars were really working, even though the type/interface setup allowed for defining your own. Fields typed with a custom scalar were converted to `any`. 

Now, all custom scalars are collected from the schema and fields typed with these scalars have the right typescript type.
You are, however, still responsible for deserialization.  The default deserialization method is `JSON.parse`.

## Typescript defined Custom Scalars

Custom Scalars can carry their own `JSDoc` comment with a `@typedef` definition to define it's typescript type.
In this type definition, you can reference other Input-, Object-, Enum- or Union Types. They need to be referenced by their exact name, so that it can work.

TODO: Validate the `@typedef` comment so that it really can only be a valid typescript type definition.