### PR TITLE
implement magic $all helper function to select all nested fields

### DIFF
--- a/packages/make/src/graphql/builder/meta.ts
+++ b/packages/make/src/graphql/builder/meta.ts
@@ -152,7 +152,7 @@ export const gatherMeta = (
                 createACustomScalarType(
                     typeName,
                     type.description ?? undefined,
-                    "any",
+                    "Record<string | number | symbol, unknown>",
                     collector,
                 ),
             );


### PR DESCRIPTION
with type-safe options to exclude certain fields
with cyclic schema detection, forcing you to define how to handle it: either exclude or select up to 5 levels of the cyclic field