### PR TITLE
Improve proxied arrays performance

### DIFF
--- a/packages/make/src/graphql/flavors/default/wrapper.ts
+++ b/packages/make/src/graphql/flavors/default/wrapper.ts
@@ -1234,15 +1234,13 @@ export class SelectionWrapper<
                                 (target[SLW_OP_RESULT_DATA_OVERRIDE] &&
                                     !slw[SLW_OP_RESULT_DATA_OVERRIDE])
                             ) {
-                                // index access detected, cloning
-                                slw = slw[SLW_CLONE]({
-                                    SLW_OP_PATH:
-                                        target[SLW_OP_PATH] +
-                                        "." +
-                                        String(prop),
-                                    OP_RESULT_DATA:
-                                        target[SLW_OP_RESULT_DATA_OVERRIDE],
-                                });
+                                // index access detected, setting the op path
+                                // with the index (coming from the slw's parent (target))
+                                // it's in the parent because the parent was cloned before
+                                slw[SLW_OP_PATH] =
+                                    target[SLW_OP_PATH] + "." + String(prop);
+                                slw[SLW_OP_RESULT_DATA_OVERRIDE] =
+                                    target[SLW_OP_RESULT_DATA_OVERRIDE];
                             }
 
                             if (

--- a/packages/make/src/graphql/flavors/default/wrapper.ts
+++ b/packages/make/src/graphql/flavors/default/wrapper.ts
@@ -1144,7 +1144,7 @@ export class SelectionWrapper<
                                 const path = target[SLW_OP_PATH]!;
 
                                 // check if the selected field is an array
-                                if (typeArrDepth) {
+                                if (typeArrDepth && Array.isArray(_data)) {
                                     if (!isNaN(+String(prop))) {
                                         const elm = target[SLW_CLONE]({
                                             SLW_OP_PATH:


### PR DESCRIPTION
Avoid unnecessary cloning of SelectionWrappers in case of array values.
In case of arrays in the fetched data, we create an array of the same size with proxy objects that have the correct path (set via SLW_OP_PATH).

A cache is used to not repeat this cloning if not needed.

Also cloning is not needed when later accessing the proxy object within the array, we just need to fix the SLW_OP_PATH by using the correct path from it's parent (the cloned array).